### PR TITLE
Safely rename KubeMastersPeer to KubeControlPlanesPeer

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # kube-masters interface
 
-This interface provides communication amongst kubernetes-masters in a cluster.
+This interface provides communication amongst kubernetes-control-planes in a cluster.
 
 ## States
 
@@ -28,15 +28,15 @@ This interface provides communication amongst kubernetes-masters in a cluster.
 
 @when('kube-masters.connected')
 def agree_on_cohorts():
-    kube_masters = endpoint_from_flag('kube-masters.connected')
+    kube_control_planes = endpoint_from_flag('kube-masters.connected')
     cohort_keys = create_cohorts_for_my_snaps()
-    kube_masters.set_cohort_keys(cohort_keys)
+    kube_control_planes.set_cohort_keys(cohort_keys)
 
 @when('kube-masters.cohorts.ready',
       'kube-control.connected')
 def send_cohorts_to_workers():
-    kube_masters = endpoint_from_flag('kube-masters.cohorts.ready')
-    cohort_keys = kube_masters.cohort_keys
+    kube_control_planes = endpoint_from_flag('kube-masters.cohorts.ready')
+    cohort_keys = kube_control_planes.cohort_keys
 
     kube_control = endpoint_from_flag('kube-control.connected')
     # The following set method is defined in interface-kube-control

--- a/interface.yaml
+++ b/interface.yaml
@@ -1,4 +1,4 @@
 name: kube-masters
-summary: Provides master peer communication.
+summary: Provides control-plane peer communication.
 version: 1
 maintainer: "Kevin W. Monroe <kevin.monroe@canonical.com>"

--- a/peers.py
+++ b/peers.py
@@ -19,9 +19,9 @@ from charms.reactive import (
 from charmhelpers.core.hookenv import log
 
 
-class KubeMastersPeer(Endpoint):
+class KubeControlPlanePeer(Endpoint):
     """
-    Implements peering for kubernetes-master units.
+    Implements peering for kubernetes-control-plane units.
     """
     def manage_flags(self):
         """


### PR DESCRIPTION
Don't necessarily change the relation/endpoint name just yet, just the name of the class around the Peer relation
Rename example code and comments